### PR TITLE
Typos et pbe hiérarchie de titres

### DIFF
--- a/1-gabarit-general.md
+++ b/1-gabarit-general.md
@@ -187,7 +187,7 @@ Souvent, dans le pied de page des maquettes de site web, on trouve des élément
 
 Ajouter les landmarks ARIA aux balises HTML5 correspondantes permet de distinguer les autres éléments du même type qui pourraient être utilisés.
 
-Vous pourriez mettre plusieurs balises `header` ou `footer` dans votre structure de site. Ces balises pouvant être contenus dans des balises `article` ou `section` pour créer des en-têtes d'articles et des pieds d'article. Ajouter les landmarks permet de différencier toutes ces balises des balises structurant le corps principal de la page.
+Vous pourriez mettre plusieurs balises `header` ou `footer` dans votre structure de site. Ces balises pouvant être contenues dans des balises `article` ou `section` pour créer des en-têtes d'articles et des pieds d'article. Ajouter les landmarks permet de différencier toutes ces balises des balises structurant le corps principal de la page.
 
 Le validateur ressort une alerte (<span lang="en">warning</span>), mais ce n'est pas une erreur. L'alerte correspond simplement au fait que les balises HTML5 ont déjà des rôles implicites correspondant à ces propriétés (`banner` est le rôle implicite de la balise `header`). L'alerte vous signifie simplement que l'utilisation de ces rôles est peut-être inutile. Néanmoins, pour les raisons évoquées au-dessus, la position du RGAA 3 reste stricte à ce sujet.
 
@@ -195,7 +195,7 @@ Vous pouvez consulter à ce sujet [les rôles ARIA implicites sur les éléments
 
 #### Utilisation optimale
 
-Afin de rendre l'utilisation des régions (balise HTML5 et landmarks) optimale, il est toujours préférable de ne pas inclure dans l'en-tête la navigation principale par exemple. De manière générale, il est préférable de ne pas imbriquer les régions principales définies ici.
+Afin de rendre l'utilisation des régions (balises HTML5 et landmarks) optimale, il est toujours préférable de ne pas inclure dans l'en-tête la navigation principale par exemple. De manière générale, il est préférable de ne pas imbriquer les régions principales définies ici.
 
 ### <a name="plusloin"></a>Pour aller plus loin
 

--- a/2-navigation.md
+++ b/2-navigation.md
@@ -81,7 +81,7 @@ Chaque système de navigation doit avoir sur chaque ensemble de pages un ordre e
 
 Le plan du site n'est pas obligatoire, il fait partie des 3 systèmes de navigation reconnus. Si vous intégrez un plan de site, vous devez vous assurer en plus que tous les liens sont pertinents et fonctionnels. [Vous pouvez utiliser l'outil de validation des liens du W3C][13] pour vous en assurer.
 
-### <a name="titredepage"></a>Titre de pages
+### <a name="titredepage"></a>Titre de page
 
 Le titre des pages (balise `<title>`) est un élément de repère pour nombre d'utilisateurs.
 

--- a/3-contenus.md
+++ b/3-contenus.md
@@ -54,7 +54,7 @@ Il y a 3 obligations pour le titrage des contenus&nbsp;:
 - la hiérarchie de titres doit être cohérente&nbsp;;
 - tous les titres nécessaires doivent être présents.
 
-Une hiérarchie cohérente est une hiérarchie qui ne contient pas de saut dans les niveaux de titres. Par exemple, après un `h2` on doit trouver un `h3` ou un autre `h2`, mais surtout pas un `h4`.
+Une hiérarchie cohérente est une hiérarchie qui ne contient pas de saut dans les niveaux de titres. Par exemple, après un `h2` on doit trouver un `h3`, un autre `h2` ou un nouvel `h1`, mais surtout pas un `h4`.
 
 Enfin, tous les titres nécessaires à l'architecture de l'information doivent être présents. Il s'agit de proposer un plan de la page permettant de comprendre et de naviguer rapidement dans le contenu.
 

--- a/4-tableaux.md
+++ b/4-tableaux.md
@@ -53,7 +53,7 @@ Si vous utilisez un tableau de données, la structure doit ressembler à celle-c
 
 De plus, vous devez vous assurer que la linéarisation du tableau permet la compréhension du contenu&nbsp;: un tableau est lu de gauche à droite. Assurez-vous que le contenu reste compréhensible de cette manière.
 
-Note&nbsp;: L’API ARIA propose un mécanisme permettant de surcharger le rôle natif d’un élément pour proposer des composants. Ainsi, il est possible d’utiliser des tableaux de mise en forme pour construire des listes, par exemple en implémentant les rôles `list` et `listitem` sur les éléments du tableau. Si cet usage est fortement déconseillé, il est néanmoins conforme. Le tableau étant restitué comme une liste et non plus comme un tableau, il n’est pas utile de signaler qu’il s’agit d’un tableau de présentation via le rôle `presentation`.
+Note&nbsp;: l’API ARIA propose un mécanisme permettant de surcharger le rôle natif d’un élément pour proposer des composants. Ainsi, il est possible d’utiliser des tableaux de mise en forme pour construire des listes, par exemple en implémentant les rôles `list` et `listitem` sur les éléments du tableau. Si cet usage est fortement déconseillé, il est néanmoins conforme. Le tableau étant restitué comme une liste et non plus comme un tableau, il n’est pas utile de signaler qu’il s’agit d’un tableau de présentation via le rôle `presentation`.
 
 #### À propos du <code>role="presentation"</code>
 

--- a/5-liens.md
+++ b/5-liens.md
@@ -78,7 +78,7 @@ Dans le cas des liens mis en forme en CSS avec des icônes, la réparation consi
 
 ### <a name="titreliens"></a>Titre de liens <code>title</code>
 
-L'attribut <code>title</code> sert surtout à apporter une information complémentaire à l'intitulé du lien et à le rendre explicite. Il doit toujours être construit sur le modèle&nbsp;; intitulé du lien + informations complémentaires.
+L'attribut <code>title</code> sert surtout à apporter une information complémentaire à l'intitulé du lien et à le rendre explicite. Il doit toujours être construit sur le modèle&nbsp;: intitulé du lien + informations complémentaires.
 
 ````
 <a href="#" title="En savoir plus sur l'accessibilité numérique">En savoir plus</a>

--- a/6-formulaires.md
+++ b/6-formulaires.md
@@ -145,7 +145,7 @@ Selon votre choix d'implémentation d'étiquette de champ (<code>label</code>, <
 Il est très courant de trouver l'indication de champs obligatoire au moyen d'un astérisque. Cette pratique est tout à fait conforme si vous donnez une légende à ce symbole, et ce **avant** le formulaire concerné.
 
 ````
-  <p>Les champs précédés d'une étoile (\*) sont obligatoires</p>
+  <p>Les champs précédés d'une étoile (*) sont obligatoires</p>
   <form>
 	<label for="nom">Nom *</label>
 	<input type="text" id="nom" />

--- a/8-distinction-fond-forme.md
+++ b/8-distinction-fond-forme.md
@@ -171,7 +171,7 @@ Lorsqu'un élément est rendu visible sur action de l'utilisateur, le composant 
 
 <img src="img/textescaches.png" alt="" />
 
-Dans cet exemple, un bouton permet d'étendre la zone de contenu pour afficher une partie de contenus qui était cachée. Lorsque l'on active le bouton, le focus reste dessus. Une fois que le contenu est apparu, le focus est toujours sur ce bouton. L'utilisateur aveugle va alors parcourir le contenu suivant en pensant accéder au contenu qu'il a afficher avec le bouton, ce qui n'est pas le cas dans cet exemple.
+Dans cet exemple, un bouton permet d'étendre la zone de contenu pour afficher une partie de contenus qui était cachée. Lorsque l'on active le bouton, le focus reste dessus. Une fois que le contenu est apparu, le focus est toujours sur ce bouton. L'utilisateur aveugle va alors parcourir le contenu suivant en pensant accéder au contenu qu'il a affiché avec le bouton, ce qui n'est pas le cas dans cet exemple.
 
 *Une exception à cette règle&nbsp;: lorque le texte caché appartient à un composant ARIA, l'ordre dans lequel il doit être implémenté, par rapport à l'évènement déclencheur, est imposé par le motif de conception ARIA utilisé.*
 

--- a/9-images.md
+++ b/9-images.md
@@ -58,7 +58,7 @@ Concernant la balise `<embed>`, elle doit posséder un attribut `aria-hidden="tr
 
 #### Cas des images <code>svg</code>
 
-Dans le cas des images vectorielles, vous devez ajouter la propriété <code>aria-hidden="true"</code> et vous assurez qu'aucun attribut ou aucune balise ne sont présents afin de labelliser l'image&nbsp;:
+Dans le cas des images vectorielles, vous devez ajouter la propriété <code>aria-hidden="true"</code> et vous assurer qu'aucun attribut ou aucune balise ne sont présents afin de labelliser l'image&nbsp;:
 
 - les balises `<title>` et `<desc>` sont absentes ou vides&nbsp;;
 - la balise `<svg>`, ou l’un de ses enfants, est dépourvue d’attribut `title`&nbsp;;


### PR DESCRIPTION
Bonjour,

quelques typos corrigées dans ce PR (en français Requête Galliforme ? #tgif :o)

Et, c'est inclus dans ce PR, pour les [titres](https://github.com/DISIC/guide-integrateur/blob/master/3-contenus.md#titres) : 

> après un h2 on doit trouver un h3 ou un autre h2
> … ou un nouvel `h1` ! (c'est-à-dire après hN, tout de h1 à hN+1 et à l'exclusion de hN+2 et plus jusqu'à h6)

Pour le titre "Titre de page(s)", je me suis fié à l'ancre nommée (ce pourrait être Titre des pages ou Titre de page mais amha pas Titre de pages")
